### PR TITLE
feat: extract pure game logic from hooks and add 102 tests

### DIFF
--- a/client/src/hooks/useCombatEngine.ts
+++ b/client/src/hooks/useCombatEngine.ts
@@ -5,6 +5,22 @@ import { RANKS, DUNGEON_MODIFIERS, generateGatePool, rollDrop } from "@/lib/game
 import { processBossMechanics, getBossPhase } from "@/lib/game/bossMechanics";
 import { updateStatsAfterCombat, type GameStats, type CombatOutcome } from "@/lib/game/statsTracker";
 import { PLAYER_ATTACK_MSGS, BOSS_ATTACK_MSGS, BOSS_BLOCK_MSGS, CRIT_MSGS, SPIRIT_ABILITY_MSGS, BOSS_PHASE_MSGS, BOSS_DIALOGUE, FIRST_CLEAR_TEXT } from "@/lib/game/constants";
+import {
+  calcSpiritPassives,
+  applyCombatModifiers,
+  calcPlayerDamage,
+  calcBossDamage,
+  rollBlock,
+  isCriticalHit,
+  calcSpiritHealing,
+  calcFatigueGain,
+  detectPhaseTransitions,
+  calcVictoryRewards,
+  calcDefeatPenalty,
+  calcVictoryHealing,
+  gateRefreshCost,
+  applyRewardModifiers,
+} from "@/lib/game/combatSimulation";
 import type { Player, Gate, RunningState, CombatResult, Boss } from "@/lib/game/types";
 import type { ParticlePreset } from "@/lib/particles";
 
@@ -107,49 +123,14 @@ export function useCombatEngine({
         let { boss, hpEnemy, tick } = prev;
 
         // Apply spirit passive abilities
-        let spiritDmgBonus = 0;
-        let spiritBlockChance = 0;
-        let spiritHealPerTick = 0;
-
-        for (const spirit of player.spirits) {
-          for (const ability of (spirit.abilities || [])) {
-            if (ability.type !== "passive") continue;
-            switch (ability.id) {
-              case "berserker_rage":
-                if (player.hp < player.maxHp * 0.5) spiritDmgBonus += 0.25;
-                break;
-              case "ethereal_shield":
-                spiritBlockChance += 0.15;
-                break;
-              case "shadow_step":
-                if (tick % 3 === 0) spiritDmgBonus += 0.10;
-                break;
-              case "vitality_aura":
-                spiritHealPerTick += 2;
-                break;
-              case "mana_shield":
-                // Converts some mana damage to reduced physical: handled implicitly by MP upkeep
-                break;
-            }
-          }
-        }
-
-        // Cap combined block chance at 75% max
-        spiritBlockChance = Math.min(spiritBlockChance, 0.75);
-        // Cap spirit damage bonus at 100% max
-        spiritDmgBonus = Math.min(spiritDmgBonus, 1.0);
+        const hpRatio = player.maxHp > 0 ? player.hp / player.maxHp : 1;
+        const { dmgBonus: spiritDmgBonus, blockChance: spiritBlockChance, healPerTick: spiritHealPerTick } =
+          calcSpiritPassives(player.spirits, hpRatio, tick);
 
         // Apply dungeon modifiers to combat
-        // Re-look up modifier by ID to restore functions lost during serialization
-        let playerDmgMult = 1 + spiritDmgBonus;
-        let bossDmgMult = 1;
-        for (const mod of (prev.gate.modifiers || [])) {
-          const liveMod = DUNGEON_MODIFIERS.find(m => m.id === mod.id) ?? mod;
-          if (typeof liveMod.applyToCombat !== "function") continue;
-          const result = liveMod.applyToCombat(playerDmgMult, bossDmgMult);
-          playerDmgMult = result.playerDmgMult;
-          bossDmgMult = result.bossDmgMult;
-        }
+        const { playerDmgMult, bossDmgMult } = applyCombatModifiers(
+          prev.gate.modifiers || [], spiritDmgBonus
+        );
 
         // Apply boss mechanics
         const previousPhase = boss.phase ?? 0;
@@ -175,30 +156,22 @@ export function useCombatEngine({
           setCombatLog((log) => [...log, ...mechResult.messages].slice(-12));
         }
 
-        // Player attack - increased base damage (with spirit bonuses, dungeon modifiers, and boss mechanics)
-        const dmgPlayer = Math.max(
-          1,
-          Math.floor(pPower * 1.2 * playerDmgMult - effectiveBossDef * 0.3 + rand(0, 6))
-        );
+        // Player attack - with spirit bonuses, dungeon modifiers, and boss mechanics
+        const dmgPlayer = calcPlayerDamage(pPower, playerDmgMult, effectiveBossDef);
         const oldHpEnemy = hpEnemy;
         hpEnemy = clamp(hpEnemy - dmgPlayer, 0, boss.maxHp);
 
         // Boss attack - with spirit block chance, dungeon modifiers, and boss mechanics
-        const blocked = spiritBlockChance > 0 && Math.random() < spiritBlockChance;
-        const dmgBoss = blocked ? 0 : Math.max(
-          0,
-          Math.floor(boss.atk * 0.8 * bossDmgMult - player.stats.VIT * 0.7 + rand(0, 3))
-        );
+        const blocked = rollBlock(spiritBlockChance);
+        const dmgBoss = calcBossDamage(boss.atk, bossDmgMult, player.stats.VIT, blocked);
         const oldHp = player.hp;
         let newHp = clamp(player.hp - dmgBoss, 0, player.maxHp);
 
         // Spirit healing
-        if (spiritHealPerTick > 0 && newHp > 0) {
-          const healAmount = Math.min(spiritHealPerTick, player.maxHp - newHp);
-          if (healAmount > 0) {
-            newHp = Math.min(newHp + healAmount, player.maxHp);
-            addDamageNumber(healAmount, "heal", "player");
-          }
+        const healAmount = calcSpiritHealing(spiritHealPerTick, newHp, player.maxHp);
+        if (healAmount > 0) {
+          newHp = Math.min(newHp + healAmount, player.maxHp);
+          addDamageNumber(healAmount, "heal", "player");
         }
 
         // Accumulate damage for statistics
@@ -209,7 +182,7 @@ export function useCombatEngine({
         if (dmgPlayer > 0) {
           triggerVisualEffect("screenShake");
           playSound("attack");
-          const isCrit = dmgPlayer > pPower * 1.5;
+          const isCrit = isCriticalHit(dmgPlayer, pPower);
           if (isCrit) {
             triggerVisualEffect("criticalHit");
             playSound("critical");
@@ -238,16 +211,15 @@ export function useCombatEngine({
         const newMp = clamp(player.mp - upkeep, 0, player.maxMp);
 
         // Fatigue gain
-        const fatigueGainMult = 1 - (prestigeUpgrades["fatigue_resist"] || 0) * 0.05;
-        const newFatigue = clamp(player.fatigue + 0.5 * fatigueGainMult, 0, 100);
+        const newFatigue = calcFatigueGain(
+          player.fatigue, prestigeUpgrades["fatigue_resist"] || 0
+        );
 
         // Add combat log entries
         const rank = prev.gate?.rank ?? "E";
-        const oldBossHpPct = boss.maxHp > 0 ? (oldHpEnemy / boss.maxHp) * 100 : 0;
-        const newBossHpPct = boss.maxHp > 0 ? (hpEnemy / boss.maxHp) * 100 : 0;
         setCombatLog((log) => {
           const newEntries: string[] = [];
-          const isCrit = dmgPlayer > pPower * 1.5;
+          const isCrit = isCriticalHit(dmgPlayer, pPower);
 
           // Player attack
           if (dmgPlayer > 0) {
@@ -267,10 +239,8 @@ export function useCombatEngine({
           }
 
           // Boss HP phase transitions
-          for (const threshold of [75, 50, 25]) {
-            if (oldBossHpPct > threshold && newBossHpPct <= threshold) {
-              newEntries.push(pick(BOSS_PHASE_MSGS[String(threshold)]));
-            }
+          for (const threshold of detectPhaseTransitions(oldHpEnemy, hpEnemy, boss.maxHp)) {
+            newEntries.push(pick(BOSS_PHASE_MSGS[String(threshold)]));
           }
 
           // Spirit ability procs (throttled to avoid spam)
@@ -315,23 +285,9 @@ export function useCombatEngine({
           playMusic("victory_music", false);
           hapticSuccess();
 
-          const { exp: rawExp, gold: rawGold } = gainExpGoldFromGate(prev.gate);
-          const expBoost = 1 + (prestigeUpgrades["exp_boost"] || 0) * 0.05;
-          const goldBoostMult = 1 + (prestigeUpgrades["gold_boost"] || 0) * 0.05;
-
-          // Apply dungeon modifiers to rewards
-          // Re-look up modifier by ID to restore functions lost during serialization
-          let expMult = expBoost;
-          let goldMult = goldBoostMult;
-          for (const mod of (prev.gate.modifiers || [])) {
-            const liveMod = DUNGEON_MODIFIERS.find(m => m.id === mod.id) ?? mod;
-            if (typeof liveMod.applyToRewards !== "function") continue;
-            const result = liveMod.applyToRewards(expMult, goldMult);
-            expMult = result.expMult;
-            goldMult = result.goldMult;
-          }
-          const exp = Math.floor(rawExp * expMult);
-          const goldGain = Math.floor(rawGold * goldMult);
+          const { exp, gold: goldGain } = calcVictoryRewards(
+            prev.gate, prestigeUpgrades
+          );
           const drop = rollDrop(prev.gate);
           const drops = drop ? [drop] : [];
 
@@ -372,11 +328,10 @@ export function useCombatEngine({
           }
 
           // Heal to full on victory
-          setPlayer((pp) => ({
-            ...pp,
-            hp: pp.maxHp,
-            mp: Math.min(pp.mp + Math.floor(pp.maxMp * 0.3), pp.maxMp),
-          }));
+          setPlayer((pp) => {
+            const healing = calcVictoryHealing(pp.mp, pp.maxHp, pp.maxMp);
+            return { ...pp, hp: healing.hp, mp: healing.mp };
+          });
 
           // First-clear celebration — queue story modal for new rank clears
           const victoryRank = prev.gate.rank;
@@ -459,12 +414,11 @@ export function useCombatEngine({
             `You were defeated in ${prev.gate.name}. Rest and try again.`
           );
           // defeat penalty: lose some gold; recover to 30% HP
-          setGold((g) => Math.max(0, g - 10));
-          setPlayer((pp) => ({
-            ...pp,
-            hp: Math.max(5, Math.floor(pp.maxHp * 0.3)),
-            mp: Math.min(pp.mp + Math.floor(pp.maxMp * 0.2), pp.maxMp),
-          }));
+          setGold((g) => calcDefeatPenalty(g, 0, 0, 0).gold);
+          setPlayer((pp) => {
+            const penalty = calcDefeatPenalty(0, pp.maxHp, pp.mp, pp.maxMp);
+            return { ...pp, hp: penalty.hp, mp: penalty.mp };
+          });
 
           // Update statistics
           updateStats(false, 0, -10, prev.gate.rank);
@@ -564,7 +518,7 @@ export function useCombatEngine({
   // Refresh gate pool
   function refreshGates() {
     if (inRun) return;
-    const cost = Math.max(10, player.level * 5);
+    const cost = gateRefreshCost(player.level);
     if (gold < cost) {
       logPush(`Not enough gold. Need ${cost}₲ to refresh gates.`);
       return;

--- a/client/src/lib/game/combatSimulation.test.ts
+++ b/client/src/lib/game/combatSimulation.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  calcSpiritPassives,
+  applyCombatModifiers,
+  calcPlayerDamage,
+  calcBossDamage,
+  rollBlock,
+  isCriticalHit,
+  calcSpiritHealing,
+  calcFatigueGain,
+  detectPhaseTransitions,
+  applyRewardModifiers,
+  calcVictoryRewards,
+  calcDefeatPenalty,
+  calcVictoryHealing,
+  gateRefreshCost,
+} from './combatSimulation';
+import type { Spirit, DungeonModifier } from './types';
+
+function makeSpirit(overrides: Partial<Spirit> = {}): Spirit {
+  return {
+    id: 'test-spirit',
+    name: 'Test Spirit',
+    power: 10,
+    rarity: 'common',
+    abilities: [],
+    level: 1,
+    exp: 0,
+    expToNext: 100,
+    type: 'warrior',
+    description: 'A test spirit',
+    ...overrides,
+  };
+}
+
+describe('combatSimulation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── calcSpiritPassives ──────────────────────────────────────────
+
+  describe('calcSpiritPassives', () => {
+    it('returns zeros with no spirits', () => {
+      const result = calcSpiritPassives([], 1.0, 0);
+      expect(result).toEqual({ dmgBonus: 0, blockChance: 0, healPerTick: 0 });
+    });
+
+    it('returns zeros with spirits that have no passive abilities', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'active_skill', name: 'Slash', description: '', type: 'active', effect: '' }],
+      });
+      const result = calcSpiritPassives([spirit], 1.0, 0);
+      expect(result).toEqual({ dmgBonus: 0, blockChance: 0, healPerTick: 0 });
+    });
+
+    it('activates berserker_rage when HP ratio < 0.5', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'berserker_rage', name: 'Berserker Rage', description: '', type: 'passive', effect: '' }],
+      });
+      const result = calcSpiritPassives([spirit], 0.3, 0);
+      expect(result.dmgBonus).toBe(0.25);
+    });
+
+    it('does not activate berserker_rage when HP ratio >= 0.5', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'berserker_rage', name: 'Berserker Rage', description: '', type: 'passive', effect: '' }],
+      });
+      const result = calcSpiritPassives([spirit], 0.5, 0);
+      expect(result.dmgBonus).toBe(0);
+    });
+
+    it('adds ethereal_shield block chance', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'ethereal_shield', name: 'Ethereal Shield', description: '', type: 'passive', effect: '' }],
+      });
+      const result = calcSpiritPassives([spirit], 1.0, 0);
+      expect(result.blockChance).toBeCloseTo(0.15);
+    });
+
+    it('caps block chance at 0.75', () => {
+      const spirits = Array.from({ length: 6 }, () =>
+        makeSpirit({
+          abilities: [{ id: 'ethereal_shield', name: 'Ethereal Shield', description: '', type: 'passive', effect: '' }],
+        })
+      );
+      // 6 * 0.15 = 0.9, capped at 0.75
+      const result = calcSpiritPassives(spirits, 1.0, 0);
+      expect(result.blockChance).toBe(0.75);
+    });
+
+    it('activates shadow_step on tick divisible by 3', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'shadow_step', name: 'Shadow Step', description: '', type: 'passive', effect: '' }],
+      });
+      expect(calcSpiritPassives([spirit], 1.0, 0).dmgBonus).toBe(0.10);
+      expect(calcSpiritPassives([spirit], 1.0, 3).dmgBonus).toBe(0.10);
+      expect(calcSpiritPassives([spirit], 1.0, 1).dmgBonus).toBe(0);
+    });
+
+    it('adds vitality_aura heal per tick', () => {
+      const spirit = makeSpirit({
+        abilities: [{ id: 'vitality_aura', name: 'Vitality Aura', description: '', type: 'passive', effect: '' }],
+      });
+      const result = calcSpiritPassives([spirit], 1.0, 0);
+      expect(result.healPerTick).toBe(2);
+    });
+
+    it('caps dmgBonus at 1.0', () => {
+      // 5 berserker spirits at low HP = 5 * 0.25 = 1.25, capped at 1.0
+      const spirits = Array.from({ length: 5 }, () =>
+        makeSpirit({
+          abilities: [{ id: 'berserker_rage', name: 'Berserker Rage', description: '', type: 'passive', effect: '' }],
+        })
+      );
+      const result = calcSpiritPassives(spirits, 0.1, 0);
+      expect(result.dmgBonus).toBe(1.0);
+    });
+
+    it('stacks multiple different passives', () => {
+      const spirits = [
+        makeSpirit({
+          abilities: [
+            { id: 'berserker_rage', name: 'Berserker Rage', description: '', type: 'passive', effect: '' },
+            { id: 'ethereal_shield', name: 'Ethereal Shield', description: '', type: 'passive', effect: '' },
+          ],
+        }),
+        makeSpirit({
+          abilities: [{ id: 'vitality_aura', name: 'Vitality Aura', description: '', type: 'passive', effect: '' }],
+        }),
+      ];
+      const result = calcSpiritPassives(spirits, 0.3, 0);
+      expect(result.dmgBonus).toBe(0.25);
+      expect(result.blockChance).toBeCloseTo(0.15);
+      expect(result.healPerTick).toBe(2);
+    });
+  });
+
+  // ── applyCombatModifiers ────────────────────────────────────────
+
+  describe('applyCombatModifiers', () => {
+    it('applies base spirit damage bonus with no modifiers', () => {
+      const result = applyCombatModifiers([], 0.25);
+      expect(result.playerDmgMult).toBeCloseTo(1.25);
+      expect(result.bossDmgMult).toBe(1);
+    });
+
+    it('applies empowered_boss modifier', () => {
+      const mod: DungeonModifier = {
+        id: 'empowered_boss', name: '', description: '', icon: '', type: 'debuff',
+        applyToRewards: (e, g) => ({ expMult: e, goldMult: g }),
+        applyToCombat: (p, b) => ({ playerDmgMult: p, bossDmgMult: b * 1.4 }),
+      };
+      const result = applyCombatModifiers([mod], 0);
+      expect(result.bossDmgMult).toBeCloseTo(1.4);
+    });
+
+    it('applies cursed_ground modifier', () => {
+      const mod: DungeonModifier = {
+        id: 'cursed_ground', name: '', description: '', icon: '', type: 'debuff',
+        applyToRewards: (e, g) => ({ expMult: e, goldMult: g }),
+        applyToCombat: (p, b) => ({ playerDmgMult: p * 0.75, bossDmgMult: b }),
+      };
+      const result = applyCombatModifiers([mod], 0);
+      expect(result.playerDmgMult).toBeCloseTo(0.75);
+    });
+  });
+
+  // ── calcPlayerDamage ────────────────────────────────────────────
+
+  describe('calcPlayerDamage', () => {
+    it('deals at least 1 damage regardless of defense', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const dmg = calcPlayerDamage(1, 1, 9999);
+      expect(dmg).toBe(1);
+    });
+
+    it('calculates damage from power, multiplier, and defense', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      // pPower*1.2*mult - def*0.3 + rand(0,6) with rand=0
+      // 100*1.2*1 - 10*0.3 + 0 = 120 - 3 = 117
+      const dmg = calcPlayerDamage(100, 1, 10);
+      expect(dmg).toBe(117);
+    });
+
+    it('includes random variance', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1 - Number.EPSILON);
+      // rand(0,6) with random~1 => 6
+      // 100*1.2*1 - 10*0.3 + 6 = 123
+      const dmg = calcPlayerDamage(100, 1, 10);
+      expect(dmg).toBe(123);
+    });
+
+    it('applies damage multiplier', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const base = calcPlayerDamage(100, 1, 10);
+      const boosted = calcPlayerDamage(100, 1.5, 10);
+      expect(boosted).toBeGreaterThan(base);
+    });
+  });
+
+  // ── calcBossDamage ──────────────────────────────────────────────
+
+  describe('calcBossDamage', () => {
+    it('returns 0 when blocked', () => {
+      const dmg = calcBossDamage(100, 1, 50, true);
+      expect(dmg).toBe(0);
+    });
+
+    it('returns at least 0 when not blocked', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const dmg = calcBossDamage(1, 1, 9999, false);
+      expect(dmg).toBe(0);
+    });
+
+    it('calculates damage from atk, multiplier, and VIT', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      // atk*0.8*mult - VIT*0.7 + rand(0,3) with rand=0
+      // 50*0.8*1 - 10*0.7 + 0 = 40 - 7 = 33
+      const dmg = calcBossDamage(50, 1, 10, false);
+      expect(dmg).toBe(33);
+    });
+  });
+
+  // ── rollBlock ───────────────────────────────────────────────────
+
+  describe('rollBlock', () => {
+    it('never blocks with 0 block chance', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      expect(rollBlock(0)).toBe(false);
+    });
+
+    it('blocks when random < blockChance', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.1);
+      expect(rollBlock(0.5)).toBe(true);
+    });
+
+    it('does not block when random >= blockChance', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.6);
+      expect(rollBlock(0.5)).toBe(false);
+    });
+  });
+
+  // ── isCriticalHit ───────────────────────────────────────────────
+
+  describe('isCriticalHit', () => {
+    it('returns true when damage exceeds 1.5x power', () => {
+      expect(isCriticalHit(160, 100)).toBe(true);
+    });
+
+    it('returns false when damage equals 1.5x power', () => {
+      expect(isCriticalHit(150, 100)).toBe(false);
+    });
+
+    it('returns false when damage is below 1.5x power', () => {
+      expect(isCriticalHit(100, 100)).toBe(false);
+    });
+  });
+
+  // ── calcSpiritHealing ──────────────────────────────────────────
+
+  describe('calcSpiritHealing', () => {
+    it('returns 0 when heal per tick is 0', () => {
+      expect(calcSpiritHealing(0, 50, 100)).toBe(0);
+    });
+
+    it('returns 0 when player HP is 0 (dead)', () => {
+      expect(calcSpiritHealing(5, 0, 100)).toBe(0);
+    });
+
+    it('heals up to the spirit heal amount', () => {
+      expect(calcSpiritHealing(5, 50, 100)).toBe(5);
+    });
+
+    it('caps healing at missing HP', () => {
+      // Only 2 HP missing, but heal is 5
+      expect(calcSpiritHealing(5, 98, 100)).toBe(2);
+    });
+
+    it('returns 0 when already at full HP', () => {
+      expect(calcSpiritHealing(5, 100, 100)).toBe(0);
+    });
+  });
+
+  // ── calcFatigueGain ─────────────────────────────────────────────
+
+  describe('calcFatigueGain', () => {
+    it('adds 0.5 fatigue with no resistance', () => {
+      expect(calcFatigueGain(0, 0)).toBeCloseTo(0.5);
+    });
+
+    it('reduces fatigue gain with resistance upgrades', () => {
+      // resist level 5: mult = 1 - 5*0.05 = 0.75, gain = 0.5*0.75 = 0.375
+      expect(calcFatigueGain(0, 5)).toBeCloseTo(0.375);
+    });
+
+    it('clamps fatigue at 100', () => {
+      expect(calcFatigueGain(99.8, 0)).toBe(100);
+    });
+
+    it('does not go below 0', () => {
+      // With absurd resist this can't actually go negative due to clamp
+      expect(calcFatigueGain(0, 0)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ── detectPhaseTransitions ──────────────────────────────────────
+
+  describe('detectPhaseTransitions', () => {
+    it('returns empty array when no thresholds crossed', () => {
+      expect(detectPhaseTransitions(90, 80, 100)).toEqual([]);
+    });
+
+    it('detects 75% threshold', () => {
+      expect(detectPhaseTransitions(80, 70, 100)).toEqual([75]);
+    });
+
+    it('detects 50% threshold', () => {
+      expect(detectPhaseTransitions(55, 45, 100)).toEqual([50]);
+    });
+
+    it('detects 25% threshold', () => {
+      expect(detectPhaseTransitions(30, 20, 100)).toEqual([25]);
+    });
+
+    it('detects multiple thresholds in one tick', () => {
+      // From 80% to 20% — crosses 75, 50, and 25
+      expect(detectPhaseTransitions(80, 20, 100)).toEqual([75, 50, 25]);
+    });
+
+    it('returns empty for zero maxHp', () => {
+      expect(detectPhaseTransitions(50, 25, 0)).toEqual([]);
+    });
+  });
+
+  // ── applyRewardModifiers ────────────────────────────────────────
+
+  describe('applyRewardModifiers', () => {
+    it('returns base multipliers with no modifiers', () => {
+      const result = applyRewardModifiers([], 1.0, 1.0);
+      expect(result.expMult).toBe(1.0);
+      expect(result.goldMult).toBe(1.0);
+    });
+
+    it('applies double_exp modifier', () => {
+      const mod: DungeonModifier = {
+        id: 'double_exp', name: '', description: '', icon: '', type: 'buff',
+        applyToRewards: (e, g) => ({ expMult: e * 2, goldMult: g }),
+        applyToCombat: (p, b) => ({ playerDmgMult: p, bossDmgMult: b }),
+      };
+      const result = applyRewardModifiers([mod], 1.0, 1.0);
+      expect(result.expMult).toBe(2.0);
+      expect(result.goldMult).toBe(1.0);
+    });
+  });
+
+  // ── calcVictoryRewards ──────────────────────────────────────────
+
+  describe('calcVictoryRewards', () => {
+    it('applies prestige exp boost', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const gate = { recommended: 100, modifiers: [] };
+      const noBoost = calcVictoryRewards(gate, {});
+      const boosted = calcVictoryRewards(gate, { exp_boost: 4 });
+      // exp_boost 4: mult = 1 + 4*0.05 = 1.20
+      expect(boosted.exp).toBeGreaterThan(noBoost.exp);
+    });
+
+    it('applies prestige gold boost', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const gate = { recommended: 100, modifiers: [] };
+      const noBoost = calcVictoryRewards(gate, {});
+      const boosted = calcVictoryRewards(gate, { gold_boost: 4 });
+      expect(boosted.gold).toBeGreaterThan(noBoost.gold);
+    });
+
+    it('returns positive values', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const result = calcVictoryRewards({ recommended: 1, modifiers: [] }, {});
+      expect(result.exp).toBeGreaterThan(0);
+      expect(result.gold).toBeGreaterThan(0);
+    });
+  });
+
+  // ── calcDefeatPenalty ───────────────────────────────────────────
+
+  describe('calcDefeatPenalty', () => {
+    it('loses 10 gold on defeat', () => {
+      const result = calcDefeatPenalty(100, 100, 50, 50);
+      expect(result.gold).toBe(90);
+    });
+
+    it('does not go below 0 gold', () => {
+      const result = calcDefeatPenalty(5, 100, 50, 50);
+      expect(result.gold).toBe(0);
+    });
+
+    it('recovers to 30% maxHp', () => {
+      const result = calcDefeatPenalty(100, 200, 50, 50);
+      expect(result.hp).toBe(60); // floor(200 * 0.3)
+    });
+
+    it('guarantees at least 5 HP', () => {
+      const result = calcDefeatPenalty(100, 10, 50, 50);
+      // floor(10 * 0.3) = 3, clamped to 5
+      expect(result.hp).toBe(5);
+    });
+
+    it('restores 20% of maxMp', () => {
+      const result = calcDefeatPenalty(100, 100, 30, 100);
+      // 30 + floor(100 * 0.2) = 30 + 20 = 50
+      expect(result.mp).toBe(50);
+    });
+
+    it('caps MP at maxMp', () => {
+      const result = calcDefeatPenalty(100, 100, 45, 50);
+      // 45 + floor(50 * 0.2) = 45 + 10 = 55, capped at 50
+      expect(result.mp).toBe(50);
+    });
+  });
+
+  // ── calcVictoryHealing ──────────────────────────────────────────
+
+  describe('calcVictoryHealing', () => {
+    it('heals HP to full', () => {
+      const result = calcVictoryHealing(30, 100, 50);
+      expect(result.hp).toBe(100);
+    });
+
+    it('restores 30% of maxMp', () => {
+      const result = calcVictoryHealing(20, 100, 100);
+      // 20 + floor(100 * 0.3) = 20 + 30 = 50
+      expect(result.mp).toBe(50);
+    });
+
+    it('caps MP at maxMp', () => {
+      const result = calcVictoryHealing(45, 100, 50);
+      // 45 + floor(50 * 0.3) = 45 + 15 = 60, capped at 50
+      expect(result.mp).toBe(50);
+    });
+  });
+
+  // ── gateRefreshCost ─────────────────────────────────────────────
+
+  describe('gateRefreshCost', () => {
+    it('returns minimum of 10 for low level', () => {
+      expect(gateRefreshCost(1)).toBe(10);
+    });
+
+    it('scales with player level', () => {
+      expect(gateRefreshCost(10)).toBe(50);
+    });
+
+    it('never goes below 10', () => {
+      expect(gateRefreshCost(0)).toBe(10);
+    });
+  });
+});

--- a/client/src/lib/game/combatSimulation.ts
+++ b/client/src/lib/game/combatSimulation.ts
@@ -1,0 +1,268 @@
+import { clamp, rand } from '@/lib/game/gameUtils';
+import { DUNGEON_MODIFIERS } from '@/lib/game/gateSystem';
+import { gainExpGoldFromGate } from '@/lib/game/gameLogic';
+import type { Boss, DungeonModifier, Spirit } from '@/lib/game/types';
+
+// ── Spirit passive ability aggregation ──────────────────────────────
+
+export interface SpiritPassives {
+  dmgBonus: number;
+  blockChance: number;
+  healPerTick: number;
+}
+
+/**
+ * Aggregate passive spirit abilities into combat bonuses.
+ * Pure function — takes spirit list, player HP ratio, and current tick.
+ */
+export function calcSpiritPassives(
+  spirits: Spirit[],
+  playerHpRatio: number,
+  tick: number,
+): SpiritPassives {
+  let dmgBonus = 0;
+  let blockChance = 0;
+  let healPerTick = 0;
+
+  for (const spirit of spirits) {
+    for (const ability of spirit.abilities || []) {
+      if (ability.type !== 'passive') continue;
+      switch (ability.id) {
+        case 'berserker_rage':
+          if (playerHpRatio < 0.5) dmgBonus += 0.25;
+          break;
+        case 'ethereal_shield':
+          blockChance += 0.15;
+          break;
+        case 'shadow_step':
+          if (tick % 3 === 0) dmgBonus += 0.10;
+          break;
+        case 'vitality_aura':
+          healPerTick += 2;
+          break;
+        // mana_shield handled implicitly by MP upkeep
+      }
+    }
+  }
+
+  // Cap combined block chance at 75% max
+  blockChance = Math.min(blockChance, 0.75);
+  // Cap spirit damage bonus at 100% max
+  dmgBonus = Math.min(dmgBonus, 1.0);
+
+  return { dmgBonus, blockChance, healPerTick };
+}
+
+// ── Dungeon modifier application ────────────────────────────────────
+
+export interface CombatMultipliers {
+  playerDmgMult: number;
+  bossDmgMult: number;
+}
+
+/**
+ * Apply dungeon modifiers to combat damage multipliers.
+ * Re-looks up live modifier by ID to restore functions lost during serialization.
+ */
+export function applyCombatModifiers(
+  modifiers: DungeonModifier[],
+  baseSpiritDmgBonus: number,
+): CombatMultipliers {
+  let playerDmgMult = 1 + baseSpiritDmgBonus;
+  let bossDmgMult = 1;
+
+  for (const mod of modifiers) {
+    const liveMod = DUNGEON_MODIFIERS.find(m => m.id === mod.id) ?? mod;
+    if (typeof liveMod.applyToCombat !== 'function') continue;
+    const result = liveMod.applyToCombat(playerDmgMult, bossDmgMult);
+    playerDmgMult = result.playerDmgMult;
+    bossDmgMult = result.bossDmgMult;
+  }
+
+  return { playerDmgMult, bossDmgMult };
+}
+
+// ── Damage calculations ─────────────────────────────────────────────
+
+/**
+ * Calculate player's damage dealt to boss this tick.
+ */
+export function calcPlayerDamage(
+  pPower: number,
+  playerDmgMult: number,
+  bossDef: number,
+): number {
+  return Math.max(1, Math.floor(pPower * 1.2 * playerDmgMult - bossDef * 0.3 + rand(0, 6)));
+}
+
+/**
+ * Calculate boss's damage dealt to player this tick.
+ * Returns 0 if blocked.
+ */
+export function calcBossDamage(
+  bossAtk: number,
+  bossDmgMult: number,
+  playerVIT: number,
+  blocked: boolean,
+): number {
+  if (blocked) return 0;
+  return Math.max(0, Math.floor(bossAtk * 0.8 * bossDmgMult - playerVIT * 0.7 + rand(0, 3)));
+}
+
+/**
+ * Determine whether a boss attack is blocked based on block chance.
+ */
+export function rollBlock(blockChance: number): boolean {
+  return blockChance > 0 && Math.random() < blockChance;
+}
+
+/**
+ * Determine whether player damage is a critical hit.
+ */
+export function isCriticalHit(dmgPlayer: number, pPower: number): boolean {
+  return dmgPlayer > pPower * 1.5;
+}
+
+// ── Healing ─────────────────────────────────────────────────────────
+
+/**
+ * Calculate spirit healing applied this tick.
+ * Returns the actual amount healed (may be less than spiritHealPerTick if near max HP).
+ */
+export function calcSpiritHealing(
+  spiritHealPerTick: number,
+  currentHp: number,
+  maxHp: number,
+): number {
+  if (spiritHealPerTick <= 0 || currentHp <= 0) return 0;
+  return Math.min(spiritHealPerTick, maxHp - currentHp);
+}
+
+// ── Resource updates ────────────────────────────────────────────────
+
+/**
+ * Calculate new fatigue after a combat tick.
+ */
+export function calcFatigueGain(
+  currentFatigue: number,
+  fatigueResistLevel: number,
+): number {
+  const fatigueGainMult = 1 - fatigueResistLevel * 0.05;
+  return clamp(currentFatigue + 0.5 * fatigueGainMult, 0, 100);
+}
+
+// ── Boss HP phase thresholds ────────────────────────────────────────
+
+/**
+ * Return which HP thresholds (75, 50, 25) were crossed this tick.
+ */
+export function detectPhaseTransitions(
+  oldHpEnemy: number,
+  newHpEnemy: number,
+  bossMaxHp: number,
+): number[] {
+  if (bossMaxHp <= 0) return [];
+  const oldPct = (oldHpEnemy / bossMaxHp) * 100;
+  const newPct = (newHpEnemy / bossMaxHp) * 100;
+  const crossed: number[] = [];
+  for (const threshold of [75, 50, 25]) {
+    if (oldPct > threshold && newPct <= threshold) {
+      crossed.push(threshold);
+    }
+  }
+  return crossed;
+}
+
+// ── Victory reward calculation ──────────────────────────────────────
+
+export interface RewardMultipliers {
+  expMult: number;
+  goldMult: number;
+}
+
+/**
+ * Apply dungeon modifiers to reward multipliers.
+ */
+export function applyRewardModifiers(
+  modifiers: DungeonModifier[],
+  baseExpMult: number,
+  baseGoldMult: number,
+): RewardMultipliers {
+  let expMult = baseExpMult;
+  let goldMult = baseGoldMult;
+
+  for (const mod of modifiers) {
+    const liveMod = DUNGEON_MODIFIERS.find(m => m.id === mod.id) ?? mod;
+    if (typeof liveMod.applyToRewards !== 'function') continue;
+    const result = liveMod.applyToRewards(expMult, goldMult);
+    expMult = result.expMult;
+    goldMult = result.goldMult;
+  }
+
+  return { expMult, goldMult };
+}
+
+/**
+ * Calculate final victory rewards (exp + gold) from gate, prestige upgrades,
+ * and dungeon modifiers.
+ */
+export function calcVictoryRewards(
+  gate: { recommended: number; modifiers: DungeonModifier[] },
+  prestigeUpgrades: Record<string, number>,
+): { exp: number; gold: number } {
+  const { exp: rawExp, gold: rawGold } = gainExpGoldFromGate(gate);
+  const expBoost = 1 + (prestigeUpgrades['exp_boost'] || 0) * 0.05;
+  const goldBoostMult = 1 + (prestigeUpgrades['gold_boost'] || 0) * 0.05;
+
+  const { expMult, goldMult } = applyRewardModifiers(
+    gate.modifiers,
+    expBoost,
+    goldBoostMult,
+  );
+
+  return {
+    exp: Math.floor(rawExp * expMult),
+    gold: Math.floor(rawGold * goldMult),
+  };
+}
+
+// ── Defeat penalty ──────────────────────────────────────────────────
+
+/**
+ * Calculate player state after defeat.
+ */
+export function calcDefeatPenalty(
+  currentGold: number,
+  maxHp: number,
+  currentMp: number,
+  maxMp: number,
+): { gold: number; hp: number; mp: number } {
+  return {
+    gold: Math.max(0, currentGold - 10),
+    hp: Math.max(5, Math.floor(maxHp * 0.3)),
+    mp: Math.min(currentMp + Math.floor(maxMp * 0.2), maxMp),
+  };
+}
+
+/**
+ * Calculate player state after victory.
+ */
+export function calcVictoryHealing(
+  currentMp: number,
+  maxHp: number,
+  maxMp: number,
+): { hp: number; mp: number } {
+  return {
+    hp: maxHp,
+    mp: Math.min(currentMp + Math.floor(maxMp * 0.3), maxMp),
+  };
+}
+
+// ── Gate refresh cost ───────────────────────────────────────────────
+
+/**
+ * Calculate the gold cost to refresh the gate pool.
+ */
+export function gateRefreshCost(playerLevel: number): number {
+  return Math.max(10, playerLevel * 5);
+}

--- a/client/src/lib/game/levelUpLogic.test.ts
+++ b/client/src/lib/game/levelUpLogic.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import {
+  nextExpThreshold,
+  processExpGain,
+  allocateStat,
+  totalStatPointsSpent,
+  EXP_SCALE,
+  POINTS_PER_LEVEL,
+  HP_PER_LEVEL,
+  MP_PER_LEVEL,
+  HP_RESTORE_FRACTION,
+  MP_RESTORE_FRACTION,
+  type LevelUpInput,
+} from "./levelUpLogic";
+
+describe("levelUpLogic", () => {
+  const baseInput: LevelUpInput = {
+    exp: 0,
+    level: 1,
+    expNext: 100,
+    points: 5,
+    maxHp: 100,
+    maxMp: 50,
+    hp: 100,
+    mp: 50,
+  };
+
+  describe("nextExpThreshold", () => {
+    it("scales EXP requirement by 1.35x", () => {
+      expect(nextExpThreshold(100)).toBe(Math.floor(100 * EXP_SCALE));
+      expect(nextExpThreshold(100)).toBe(135);
+    });
+
+    it("floors the result to an integer", () => {
+      // 135 * 1.35 = 182.25 -> 182
+      expect(nextExpThreshold(135)).toBe(182);
+    });
+
+    it("handles large thresholds", () => {
+      expect(nextExpThreshold(10000)).toBe(13500);
+    });
+  });
+
+  describe("processExpGain", () => {
+    it("adds exp without leveling when below threshold", () => {
+      const result = processExpGain(baseInput, 50);
+      expect(result.exp).toBe(50);
+      expect(result.level).toBe(1);
+      expect(result.leveledUp).toBe(false);
+      expect(result.levelsGained).toBe(0);
+    });
+
+    it("levels up when exp meets threshold exactly", () => {
+      const result = processExpGain(baseInput, 100);
+      expect(result.level).toBe(2);
+      expect(result.exp).toBe(0);
+      expect(result.leveledUp).toBe(true);
+      expect(result.levelsGained).toBe(1);
+    });
+
+    it("levels up when exp exceeds threshold with remainder", () => {
+      const result = processExpGain(baseInput, 120);
+      expect(result.level).toBe(2);
+      expect(result.exp).toBe(20);
+      expect(result.levelsGained).toBe(1);
+    });
+
+    it("handles multiple level-ups from large exp gain", () => {
+      // Need 100 for level 2, then 135 for level 3 = 235 total
+      const result = processExpGain(baseInput, 250);
+      expect(result.level).toBe(3);
+      expect(result.exp).toBe(15); // 250 - 100 - 135 = 15
+      expect(result.levelsGained).toBe(2);
+    });
+
+    it("awards 5 stat points per level", () => {
+      const result = processExpGain(baseInput, 100);
+      expect(result.points).toBe(baseInput.points + POINTS_PER_LEVEL);
+    });
+
+    it("awards correct points for multiple levels", () => {
+      const result = processExpGain(baseInput, 250);
+      expect(result.points).toBe(baseInput.points + POINTS_PER_LEVEL * 2);
+    });
+
+    it("increases maxHp by 10 and maxMp by 5 per level", () => {
+      const result = processExpGain(baseInput, 100);
+      expect(result.maxHp).toBe(baseInput.maxHp + HP_PER_LEVEL);
+      expect(result.maxMp).toBe(baseInput.maxMp + MP_PER_LEVEL);
+    });
+
+    it("restores HP to at least 60% of new maxHp after leveling", () => {
+      const lowHpInput: LevelUpInput = { ...baseInput, hp: 10 };
+      const result = processExpGain(lowHpInput, 100);
+      // maxHp = 110, 60% = 66
+      expect(result.hp).toBe(Math.floor(result.maxHp * HP_RESTORE_FRACTION));
+    });
+
+    it("restores MP to at least 50% of new maxMp after leveling", () => {
+      const lowMpInput: LevelUpInput = { ...baseInput, mp: 5 };
+      const result = processExpGain(lowMpInput, 100);
+      // maxMp = 55, 50% = 27
+      expect(result.mp).toBe(Math.floor(result.maxMp * MP_RESTORE_FRACTION));
+    });
+
+    it("does not reduce HP if already above restore fraction", () => {
+      const fullHpInput: LevelUpInput = { ...baseInput, hp: 100 };
+      const result = processExpGain(fullHpInput, 100);
+      // hp 100 > floor(110 * 0.6) = 66, so keep 100
+      expect(result.hp).toBe(100);
+    });
+
+    it("scales exp thresholds correctly across multiple levels", () => {
+      const result = processExpGain(baseInput, 250);
+      // After level 2: expNext = 135, after level 3: expNext = floor(135*1.35) = 182
+      expect(result.expNext).toBe(182);
+    });
+
+    it("does not restore HP/MP when no level is gained", () => {
+      const lowInput: LevelUpInput = { ...baseInput, hp: 10, mp: 5 };
+      const result = processExpGain(lowInput, 50);
+      expect(result.hp).toBe(10);
+      expect(result.mp).toBe(5);
+    });
+  });
+
+  describe("allocateStat", () => {
+    const stats = { STR: 5, AGI: 5, INT: 5, VIT: 5, LUCK: 5 };
+
+    it("increments the chosen stat by 1", () => {
+      const result = allocateStat(stats, 3, "STR");
+      expect(result).not.toBeNull();
+      expect(result!.stats.STR).toBe(6);
+    });
+
+    it("decrements available points by 1", () => {
+      const result = allocateStat(stats, 3, "AGI");
+      expect(result!.points).toBe(2);
+    });
+
+    it("returns null when no points available", () => {
+      expect(allocateStat(stats, 0, "STR")).toBeNull();
+    });
+
+    it("does not mutate the original stats object", () => {
+      const original = { ...stats };
+      allocateStat(stats, 3, "INT");
+      expect(stats).toEqual(original);
+    });
+
+    it("works for each stat type", () => {
+      const statKeys: (keyof typeof stats)[] = ["STR", "AGI", "INT", "VIT", "LUCK"];
+      for (const key of statKeys) {
+        const result = allocateStat(stats, 1, key);
+        expect(result!.stats[key]).toBe(stats[key] + 1);
+      }
+    });
+  });
+
+  describe("totalStatPointsSpent", () => {
+    it("returns 0 for initial stats (all 5s)", () => {
+      expect(totalStatPointsSpent({ STR: 5, AGI: 5, INT: 5, VIT: 5, LUCK: 5 })).toBe(0);
+    });
+
+    it("counts points allocated above initial values", () => {
+      expect(totalStatPointsSpent({ STR: 10, AGI: 5, INT: 5, VIT: 5, LUCK: 5 })).toBe(5);
+    });
+
+    it("sums across all stats", () => {
+      expect(totalStatPointsSpent({ STR: 8, AGI: 7, INT: 6, VIT: 9, LUCK: 10 })).toBe(15);
+    });
+  });
+});

--- a/client/src/lib/game/levelUpLogic.ts
+++ b/client/src/lib/game/levelUpLogic.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure level-up calculation functions extracted from useLevelUp hook.
+ * No React state or side effects — just math.
+ */
+
+export interface LevelUpInput {
+  exp: number;
+  level: number;
+  expNext: number;
+  points: number;
+  maxHp: number;
+  maxMp: number;
+  hp: number;
+  mp: number;
+}
+
+export interface LevelUpResult {
+  exp: number;
+  level: number;
+  expNext: number;
+  points: number;
+  maxHp: number;
+  maxMp: number;
+  hp: number;
+  mp: number;
+  levelsGained: number;
+  leveledUp: boolean;
+}
+
+/** EXP scaling factor per level. */
+export const EXP_SCALE = 1.35;
+/** Stat points awarded per level. */
+export const POINTS_PER_LEVEL = 5;
+/** Max HP gained per level. */
+export const HP_PER_LEVEL = 10;
+/** Max MP gained per level. */
+export const MP_PER_LEVEL = 5;
+/** After leveling, HP is restored to at least this fraction of maxHp. */
+export const HP_RESTORE_FRACTION = 0.6;
+/** After leveling, MP is restored to at least this fraction of maxMp. */
+export const MP_RESTORE_FRACTION = 0.5;
+
+/**
+ * Calculate EXP required for the next level given the current threshold.
+ */
+export function nextExpThreshold(currentExpNext: number): number {
+  return Math.floor(currentExpNext * EXP_SCALE);
+}
+
+/**
+ * Process gaining EXP, potentially leveling up multiple times.
+ * Returns the new player values and how many levels were gained.
+ */
+export function processExpGain(input: LevelUpInput, addExp: number): LevelUpResult {
+  let { exp, level, expNext, points, maxHp, maxMp, hp, mp } = input;
+  exp += addExp;
+  let levelsGained = 0;
+
+  while (exp >= expNext) {
+    exp -= expNext;
+    level += 1;
+    levelsGained += 1;
+    expNext = nextExpThreshold(expNext);
+    points += POINTS_PER_LEVEL;
+    maxHp += HP_PER_LEVEL;
+    maxMp += MP_PER_LEVEL;
+  }
+
+  // Restore HP/MP to minimum fraction after leveling
+  if (levelsGained > 0) {
+    hp = Math.max(hp, Math.floor(maxHp * HP_RESTORE_FRACTION));
+    mp = Math.max(mp, Math.floor(maxMp * MP_RESTORE_FRACTION));
+  }
+
+  return {
+    exp, level, expNext, points, maxHp, maxMp, hp, mp,
+    levelsGained,
+    leveledUp: levelsGained > 0,
+  };
+}
+
+/**
+ * Allocate a single stat point.
+ * Returns null if no points available.
+ */
+export function allocateStat(
+  stats: { STR: number; AGI: number; INT: number; VIT: number; LUCK: number },
+  points: number,
+  stat: keyof typeof stats,
+): { stats: typeof stats; points: number } | null {
+  if (points <= 0) return null;
+  return {
+    stats: { ...stats, [stat]: stats[stat] + 1 },
+    points: points - 1,
+  };
+}
+
+/**
+ * Calculate the total stat points spent (current stats minus initial 5 each).
+ */
+export function totalStatPointsSpent(stats: { STR: number; AGI: number; INT: number; VIT: number; LUCK: number }): number {
+  const initial = 5;
+  return (stats.STR - initial) + (stats.AGI - initial) + (stats.INT - initial) + (stats.VIT - initial) + (stats.LUCK - initial);
+}

--- a/client/src/lib/game/spiritBindingLogic.test.ts
+++ b/client/src/lib/game/spiritBindingLogic.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  canAttemptBinding,
+  calcSpiritPower,
+  mpAfterBinding,
+  getBindingSequenceText,
+  isBindingSuccessful,
+  BINDING_MP_COST,
+  type BindingPhase,
+} from "./spiritBindingLogic";
+
+describe("spiritBindingLogic", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("canAttemptBinding", () => {
+    it("returns true when MP equals cost", () => {
+      expect(canAttemptBinding(BINDING_MP_COST)).toBe(true);
+    });
+
+    it("returns true when MP exceeds cost", () => {
+      expect(canAttemptBinding(50)).toBe(true);
+    });
+
+    it("returns false when MP is below cost", () => {
+      expect(canAttemptBinding(9)).toBe(false);
+    });
+
+    it("returns false when MP is zero", () => {
+      expect(canAttemptBinding(0)).toBe(false);
+    });
+  });
+
+  describe("calcSpiritPower", () => {
+    it("calculates power from INT and boss rank", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      // floor(5 + 10*0.8 + 2*6 + rand(0,8)) where rand with 0.5 → floor(0.5*9)+0 = 4
+      // floor(5 + 8 + 12 + 4) = 29
+      expect(calcSpiritPower(10, 2)).toBe(29);
+    });
+
+    it("scales with INT stat", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const lowInt = calcSpiritPower(5, 0);
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const highInt = calcSpiritPower(30, 0);
+      expect(highInt).toBeGreaterThan(lowInt);
+    });
+
+    it("scales with boss rank index", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const lowRank = calcSpiritPower(10, 0);
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const highRank = calcSpiritPower(10, 5);
+      expect(highRank).toBeGreaterThan(lowRank);
+    });
+
+    it("has minimum power of 5 with zero stats and low roll", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0); // rand(0,8) → 0
+      expect(calcSpiritPower(0, 0)).toBe(5);
+    });
+  });
+
+  describe("mpAfterBinding", () => {
+    it("subtracts binding cost from current MP", () => {
+      expect(mpAfterBinding(50)).toBe(50 - BINDING_MP_COST);
+    });
+
+    it("floors at zero when MP equals cost", () => {
+      expect(mpAfterBinding(BINDING_MP_COST)).toBe(0);
+    });
+
+    it("floors at zero when MP is below cost", () => {
+      expect(mpAfterBinding(5)).toBe(0);
+    });
+  });
+
+  describe("getBindingSequenceText", () => {
+    it("returns preparing text", () => {
+      const text = getBindingSequenceText("preparing", "Shadow King", 0);
+      expect(text.title).toBe("Spirit Binding Initiated");
+      expect(text.subtitle).toContain("Shadow King");
+    });
+
+    it("returns extracting text with progress", () => {
+      const text = getBindingSequenceText("extracting", "Shadow King", 75);
+      expect(text.subtitle).toBe("75% Complete");
+    });
+
+    it("returns success text with boss name", () => {
+      const text = getBindingSequenceText("success", "Shadow King", 100);
+      expect(text.title).toBe("Binding Successful!");
+      expect(text.subtitle).toContain("Shadow King");
+    });
+
+    it("returns failure text", () => {
+      const text = getBindingSequenceText("failure", "Shadow King", 100);
+      expect(text.title).toBe("Binding Failed");
+    });
+
+    it("returns empty strings for null phase", () => {
+      const text = getBindingSequenceText(null, "", 0);
+      expect(text.title).toBe("");
+      expect(text.subtitle).toBe("");
+      expect(text.description).toBe("");
+    });
+  });
+
+  describe("isBindingSuccessful", () => {
+    it("returns true when roll is below chance", () => {
+      expect(isBindingSuccessful(0.2, 0.5)).toBe(true);
+    });
+
+    it("returns false when roll equals chance", () => {
+      expect(isBindingSuccessful(0.5, 0.5)).toBe(false);
+    });
+
+    it("returns false when roll exceeds chance", () => {
+      expect(isBindingSuccessful(0.8, 0.5)).toBe(false);
+    });
+
+    it("always succeeds with chance of 1", () => {
+      expect(isBindingSuccessful(0.99, 1.0)).toBe(true);
+    });
+
+    it("never succeeds with chance of 0", () => {
+      expect(isBindingSuccessful(0.0, 0.0)).toBe(false);
+    });
+  });
+});

--- a/client/src/lib/game/spiritBindingLogic.ts
+++ b/client/src/lib/game/spiritBindingLogic.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure spirit binding calculation functions extracted from useSpiritBinding hook.
+ * Complements spiritSystem.ts (spirit creation) and gameLogic.ts (calcBindingChance).
+ * No React state or side effects — just math.
+ */
+
+import { rand } from "@/lib/game/gameUtils";
+
+/** MP cost to attempt a spirit binding. */
+export const BINDING_MP_COST = 10;
+
+/**
+ * Check whether the player can attempt a binding (has enough MP).
+ */
+export function canAttemptBinding(mp: number): boolean {
+  return mp >= BINDING_MP_COST;
+}
+
+/**
+ * Calculate the spirit power when binding via the tryBinding path.
+ * Formula: floor(5 + INT * 0.8 + bossRankIdx * 6 + rand(0, 8))
+ */
+export function calcSpiritPower(intStat: number, bossRankIdx: number): number {
+  return Math.floor(5 + intStat * 0.8 + bossRankIdx * 6 + rand(0, 8));
+}
+
+/**
+ * Determine the MP remaining after a binding attempt.
+ */
+export function mpAfterBinding(currentMp: number): number {
+  return Math.max(0, currentMp - BINDING_MP_COST);
+}
+
+export type BindingPhase = "preparing" | "extracting" | "success" | "failure" | null;
+
+export interface BindingSequenceText {
+  title: string;
+  subtitle: string;
+  description: string;
+}
+
+/**
+ * Get the display text for a binding sequence phase.
+ * Pure function — no React state needed.
+ */
+export function getBindingSequenceText(
+  phase: BindingPhase,
+  bossName: string,
+  progress: number,
+): BindingSequenceText {
+  switch (phase) {
+    case "preparing":
+      return {
+        title: "Spirit Binding Initiated",
+        subtitle: `Preparing to bind spirit from ${bossName}...`,
+        description: "Gathering magical energy and focusing your will...",
+      };
+    case "extracting":
+      return {
+        title: "Binding Spirit",
+        subtitle: `${progress}% Complete`,
+        description: "The spirit essence is being drawn forth...",
+      };
+    case "success":
+      return {
+        title: "Binding Successful!",
+        subtitle: `${bossName}'s spirit joins you!`,
+        description: "A new spirit ally has been bound to your will.",
+      };
+    case "failure":
+      return {
+        title: "Binding Failed",
+        subtitle: "The spirit crumbles to dust...",
+        description: "The essence was too weak or your focus wavered.",
+      };
+    default:
+      return { title: "", subtitle: "", description: "" };
+  }
+}
+
+/**
+ * Determine binding outcome given a roll and chance.
+ */
+export function isBindingSuccessful(roll: number, chance: number): boolean {
+  return roll < chance;
+}


### PR DESCRIPTION
## Summary
- Extract combat simulation, level-up, and spirit binding calculations from React hooks into standalone pure-function modules
- Add comprehensive test suites: **102 new tests** (combatSimulation: 58, levelUpLogic: 23, spiritBindingLogic: 21)
- Refactor `useCombatEngine` to import extracted functions — integrates cleanly with new boss mechanics from #37
- Total: **338 tests across 17 files, all passing**

### New files
| Module | Functions | Tests |
|---|---|---|
| `combatSimulation.ts` | 14 (calcPlayerDamage, calcBossDamage, rollBlock, isCriticalHit, calcSpiritPassives, applyCombatModifiers, calcSpiritHealing, calcFatigueGain, detectPhaseTransitions, applyRewardModifiers, calcVictoryRewards, calcDefeatPenalty, calcVictoryHealing, gateRefreshCost) | 58 |
| `levelUpLogic.ts` | 4 (nextExpThreshold, processExpGain, allocateStat, totalStatPointsSpent) | 23 |
| `spiritBindingLogic.ts` | 5 (canAttemptBinding, calcSpiritPower, mpAfterBinding, getBindingSequenceText, isBindingSuccessful) | 21 |

## Test plan
- [x] All 338 tests pass (`npx vitest run`)
- [x] TypeScript compiles with zero errors
- [x] Existing tests unchanged and still passing
- [x] Merge conflict with boss mechanics (#37) resolved — extracted functions now use `effectiveBossDef` from mechResult

🤖 Generated with [Claude Code](https://claude.com/claude-code)